### PR TITLE
Added includes examples from pandoc scripting page

### DIFF
--- a/examples/includes.py
+++ b/examples/includes.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+"""
+Pandoc filter to process code blocks with class "include" and
+replace their content with the included file
+"""
+
+from pandocfilters import toJSONFilter
+
+
+def code_include(key, value, format, meta):
+    if key == 'CodeBlock':
+        [[ident, classes, namevals], code] = value
+        for nameval in namevals:
+            if 'include' in nameval:
+                with open(nameval[1], 'rb') as content_file:
+                    content = unicode(content_file.read())
+                return {'CodeBlock': [[ident, classes, namevals], content]}
+
+if __name__ == "__main__":
+    toJSONFilter(code_include)


### PR DESCRIPTION
Added a converted python example of "include" from the pandoc scripting page

``` .haskell
#!/usr/bin/env runhaskell
-- includes.hs
import Text.Pandoc.JSON

doInclude :: Block -> IO Block
doInclude cb@(CodeBlock (id, classes, namevals) contents) =
  case lookup "include" namevals of
       Just f     -> return . (CodeBlock (id, classes, namevals)) =<< readFile f
       Nothing    -> return cb
doInclude x = return x

main :: IO ()
main = toJSONFilter doInclude
```
