### PR TITLE
Fix creation of json for image (pandoc 1.12.3.3)

### DIFF
--- a/examples/graphviz.py
+++ b/examples/graphviz.py
@@ -41,7 +41,7 @@ def graphviz(key, value, format, meta):
         G.draw(src)
         sys.stderr.write('Created image ' + src + '\n')
       tit = ""
-      return Para([Image(alt, [src,tit])])
+      return Para([Image([alt], [src,tit])])
 
 if __name__ == "__main__":
   toJSONFilter(graphviz)


### PR DESCRIPTION
At least with pandoc 1.12.3.3 otherwise you get an error

```
pandoc: when expecting a [a], encountered Object instead
```
