### PR TITLE
Add inlinenotes.py

### DIFF
--- a/examples/inlinenotes.py
+++ b/examples/inlinenotes.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+from pandocfilters import toJSONFilter, RawInline, Space, Str, walk
+
+"""
+Pandoc filter for Markdown that converts most endnotes into
+Pandoc's inline notes. If input notes had multiple paragraphs,
+the paragraphs are joined by a space. But if an input note
+had any blocks other than paragraphs, the note is left as is.
+"""
+
+def query(k, v, f, meta):
+    global inlines
+    if k == 'BlockQuote':
+        inlines.append(v)
+    elif isinstance(v, list):
+        if inlines and k == 'Para':
+            inlines.append(Space())
+        inlines.extend(v)
+    return v
+
+def inlinenotes(k, v, f, meta):
+    global inlines
+    inlines = []
+    if k == 'Note' and f == 'markdown':
+       walk(v, query, f, meta)
+       if all(isinstance(x, dict) for x in inlines):
+           return [RawInline('html', '^[')] + inlines + [Str(']')]
+
+if __name__ == "__main__":
+    toJSONFilter(inlinenotes)


### PR DESCRIPTION
An example filter that converts simple endnotes into inline notes in Markdown output, and leaves more complex endnotes as they are. This is an improved version of #10 that handles empty notes as well as notes that contained block elements.
