### PR TITLE
Attribute class: parse / emit formatted attributes

### DIFF
--- a/pandocfilters.py
+++ b/pandocfilters.py
@@ -7,8 +7,10 @@ Functions to aid writing python scripts that process the pandoc
 AST serialized as JSON.
 """
 
+import re
 import sys
 import json
+from collections import OrderedDict
 
 
 def walk(x, action, format, meta):
@@ -86,15 +88,214 @@ def stringify(x):
     return ''.join(result)
 
 
-def attributes(attrs):
+def attributes(attrs={}):
     """Returns an attribute list, constructed from the
     dictionary attrs.
     """
-    attrs = attrs or {}
-    ident = attrs.get("id", "")
-    classes = attrs.get("classes", [])
-    keyvals = [[x, attrs[x]] for x in attrs if (x != "classes" and x != "id")]
-    return [ident, classes, keyvals]
+    attr = Attributes(attrs, format='dict')
+    return attr.to_pandoc()
+
+
+class Attributes(object):
+    """Parser / Emitter for pandoc block attributes.
+
+    Can read and write attributes in any of these formats:
+        - markdown
+        - html
+        - dictionary
+        - pandoc
+
+    usage:
+        attrs = '#id .class1 .class2 key=value'
+        attributes = PandocAttributes(attrs, format='markdown')
+
+        attributes.to_markdown()
+        >>> '{#id .class1 .class2 key=value}'
+
+        attributes.to_dict()
+        >>> {'id': 'id', 'classes': ['class1', 'class2'], 'key'='value'}
+
+        attributes.to_html()
+        >>> id="id" class="class1 class2" key='value'
+
+        attributes.to_pandoc()
+        >>> ['id', ['class1', 'class2'], [['key', 'value']]]
+
+        attributes.id
+        >>> 'id'
+
+        attributes.classes
+        >>> ['class1', 'class2']
+
+        attributes.kvs
+        >>> OrderedDict([('key', 'value')])
+    """
+    spnl = ' \n'
+    split_regex = r'''((?:[^{separator}"']|"[^"]*"|'[^']*')+)'''.format
+
+    def __init__(self, attr=None, format='pandoc'):
+        if attr is None:
+            id = ''
+            classes = []
+            kvs = OrderedDict()
+        elif format == 'pandoc':
+            id, classes, kvs = self.parse_pandoc(attr)
+        elif format == 'markdown':
+            id, classes, kvs = self.parse_markdown(attr)
+        elif format == 'html':
+            id, classes, kvs = self.parse_html(attr)
+        elif format == 'dict':
+            id, classes, kvs = self.parse_dict(attr)
+        else:
+            raise UserWarning('invalid format')
+
+        self.id = id
+        self.classes = classes
+        self.kvs = kvs
+
+    @classmethod
+    def parse_pandoc(self, attrs):
+        """Read pandoc attributes."""
+        id = attrs[0]
+        classes = attrs[1]
+        kvs = OrderedDict(attrs[2])
+
+        return id, classes, kvs
+
+    @classmethod
+    def parse_markdown(self, attr_string):
+        """Read markdown attributes."""
+        attr_string = attr_string.strip('{}')
+        splitter = re.compile(self.split_regex(separator=self.spnl))
+        attrs = splitter.split(attr_string)[1::2]
+
+        # match single word attributes e.g. ```python
+        if len(attrs) == 1 \
+                and not attr_string.startswith(('#', '.')) \
+                and '=' not in attr_string:
+            return '', [attr_string], OrderedDict()
+
+        try:
+            id = [a[1:] for a in attrs if a.startswith('#')][0]
+        except IndexError:
+            id = ''
+
+        classes = [a[1:] for a in attrs if a.startswith('.')]
+        special = ['unnumbered' for a in attrs if a == '-']
+        classes.extend(special)
+
+        kvs = OrderedDict(a.split('=', 1) for a in attrs if '=' in a)
+
+        return id, classes, kvs
+
+    def parse_html(self, attr_string):
+        """Read a html string to attributes."""
+        splitter = re.compile(self.split_regex(separator=self.spnl))
+        attrs = splitter.split(attr_string)[1::2]
+
+        idre = re.compile(r'''id=["']?([\w ]*)['"]?''')
+        clsre = re.compile(r'''class=["']?([\w ]*)['"]?''')
+
+        id_matches = [idre.search(a) for a in attrs]
+        cls_matches = [clsre.search(a) for a in attrs]
+
+        try:
+            id = [m.groups()[0] for m in id_matches if m][0]
+        except IndexError:
+            id = ''
+
+        classes = [m.groups()[0] for m in cls_matches if m][0].split()
+
+        special = ['unnumbered' for a in attrs if '-' in a]
+        classes.extend(special)
+
+        kvs = [a.split('=', 1) for a in attrs if '=' in a]
+        kvs = OrderedDict((k, v) for k, v in kvs if k not in ('id', 'class'))
+
+        return id, classes, kvs
+
+    @classmethod
+    def parse_dict(self, attrs):
+        """Read a dict to attributes."""
+        attrs = attrs or {}
+        ident = attrs.get("id", "")
+        classes = attrs.get("classes", [])
+        kvs = OrderedDict((k, v) for k, v in attrs.items()
+                          if k not in ("classes", "id"))
+
+        return ident, classes, kvs
+
+    def to_markdown(self, format='{id} {classes} {kvs}', surround=True):
+        """Returns attributes formatted as markdown with optional
+        format argument to determine order of attribute contents.
+        """
+        id = '#' + self.id if self.id else ''
+        classes = ' '.join('.' + cls for cls in self.classes)
+        kvs = ' '.join('{}={}'.format(k, v) for k, v in self.kvs.items())
+
+        attrs = format.format(id=id, classes=classes, kvs=kvs).strip()
+
+        if surround:
+            return '{' + attrs + '}'
+        elif not surround:
+            return attrs
+
+    def to_html(self):
+        """Returns attributes formatted as html."""
+        id, classes, kvs = self.id, self.classes, self.kvs
+        id_str = 'id="{}"'.format(id) if id else ''
+        class_str = 'class="{}"'.format(' '.join(classes)) if classes else ''
+        key_str = ' '.join('{}={}'.format(k, v) for k, v in kvs.items())
+        return ' '.join((id_str, class_str, key_str)).strip()
+
+    def to_dict(self):
+        """Returns attributes formatted as a dictionary."""
+        d = {'id': self.id, 'classes': self.classes}
+        d.update(self.kvs)
+        return d
+
+    def to_pandoc(self):
+        kvs = [[k, v] for k, v in self.kvs.items()]
+        return [self.id, self.classes, kvs]
+
+    @property
+    def markdown(self):
+        return self.to_markdown()
+
+    @property
+    def html(self):
+        return self.to_html()
+
+    @property
+    def dict(self):
+        return self.to_dict()
+
+    @property
+    def list(self):
+        return self.to_pandoc()
+
+    @property
+    def is_empty(self):
+        return self.id == '' and self.classes == [] and self.kvs == {}
+
+    def __getitem__(self, item):
+        if item == 'id':
+            return self.id
+        elif item == 'classes':
+            return self.classes
+        else:
+            return self.kvs.get(item) or {}
+
+    def __setitem__(self, key, value):
+        if key == 'id':
+            self.id = value
+        elif key == 'classes':
+            self.classes = value
+        else:
+            self.kvs[key] = value
+
+    def __repr__(self):
+        return "pandocfilters.Attributes({})".format(self.to_pandoc())
 
 
 def elt(eltType, numargs):

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,136 @@
+import nose.tools as nt
+
+from collections import OrderedDict
+
+from pandocfilters import Attributes, attributes
+
+
+attr_markdown = r"""{#identify .class1 .class2 .unnumbered
+key1=blah key2="o'brien = 1"}"""
+
+attr_markdown_special = r"""{#identify .class1 .class2
+key1=blah key2="o'brien = 1" -}"""
+
+attr_dict = OrderedDict()
+attr_dict['id'] = 'identify'
+attr_dict['classes'] = ['class1', 'class2', 'unnumbered']
+attr_dict['key1'] = 'blah'
+attr_dict['key2'] = '"o\'brien = 1"'
+
+attr_html = ('''id="identify" '''
+             '''class="class1 class2 unnumbered" '''
+             '''key1=blah key2="o'brien = 1"''')
+
+attr_pandoc = ['identify',
+               ['class1', 'class2', 'unnumbered'],
+               [['key1', 'blah'],
+                ['key2', '"o\'brien = 1"']]
+               ]
+
+
+def test_original():
+    """Check that the original behaviour of pandocfilters.attributes
+    is the same.
+    """
+    assert(attributes(attr_dict) == attr_pandoc)
+
+
+def test_markdown():
+    attr = Attributes(attr_markdown, 'markdown')
+
+    print attr_dict
+    print attr.to_dict()
+    nt.assert_dict_equal(attr_dict, attr.to_dict())
+    nt.assert_equal(attr_html, attr.to_html())
+    nt.assert_equal(attr_markdown.replace('\n', ' '), attr.to_markdown())
+    assert(attr_pandoc == attr.to_pandoc())
+
+
+def test_html():
+    attr = Attributes(attr_html, 'html')
+
+    print attr_dict
+    print attr.to_dict()
+    nt.assert_dict_equal(attr_dict, attr.to_dict())
+    nt.assert_equal(attr_html, attr.to_html())
+    nt.assert_equal(attr_markdown.replace('\n', ' '), attr.to_markdown())
+    assert(attr_pandoc == attr.to_pandoc())
+
+
+def test_dict():
+    attr = Attributes(attr_dict, 'dict')
+
+    print attr_dict
+    print attr.to_dict()
+    nt.assert_dict_equal(attr_dict, attr.to_dict())
+    nt.assert_equal(attr_html, attr.to_html())
+    nt.assert_equal(attr_markdown.replace('\n', ' '), attr.to_markdown())
+    assert(attr_pandoc == attr.to_pandoc())
+
+
+def test_pandoc():
+    attr = Attributes(attr_pandoc, 'pandoc')
+
+    print attr_dict
+    print attr.to_dict()
+    nt.assert_dict_equal(attr_dict, attr.to_dict())
+    nt.assert_equal(attr_html, attr.to_html())
+    nt.assert_equal(attr_markdown.replace('\n', ' '), attr.to_markdown())
+    assert(attr_pandoc == attr.to_pandoc())
+
+
+def test_markdown_special():
+    attr = Attributes(attr_markdown, 'markdown')
+    attr_special = Attributes(attr_markdown_special, 'markdown')
+
+    assert(attr.id == attr_special.id)
+    assert(attr.classes == attr_special.classes)
+    assert(attr.kvs == attr_special.kvs)
+
+
+def test_markdown_single():
+    attr = Attributes('python', 'markdown')
+
+    assert(attr.id == '')
+    assert(attr.classes == ['python'])
+    assert(attr.kvs == OrderedDict())
+
+
+def test_empty():
+    attr = Attributes()
+    assert attr.is_empty
+
+
+def test_getitem():
+    attr = Attributes()
+    assert attr['id'] == ''
+    assert attr['classes'] == []
+    assert not attr['whatever']
+    attr.kvs['whatever'] = 'dude'
+    assert attr['whatever'] == 'dude'
+
+
+def test_markdown_format():
+    attr = Attributes()
+    attr.id = 'a'
+    attr.classes = ['b']
+    attr.kvs['c'] = 'd'
+
+    md = attr.to_markdown(format='{classes} {id} {kvs}')
+    assert(md == '{.b #a c=d}')
+
+
+def test_properties():
+    attr = Attributes(attr_markdown, 'markdown')
+    assert(attr.html == attr.to_html())
+    assert(attr.markdown == attr.to_markdown())
+    assert(attr.dict == attr.to_dict())
+    assert(attr.list == attr.to_pandoc())
+
+
+def test_surround():
+    attr = Attributes(attr_markdown, 'markdown')
+    print attr.to_markdown(surround=False)
+    print attr_markdown.replace('\n', ' ').strip('{}')
+    assert(attr.to_markdown(surround=False)
+           == attr_markdown.replace('\n', ' ').strip('{}'))


### PR DESCRIPTION
This implements a powerful Attribute object that allows for easy
conversion between different attribute representations.

I've found this useful when writing more advanced filters and have it on pypi
already (`pip install pandoc-attributes`). Maybe it would be useful here? I've
included fairly comprehensive tests.

If nothing else, it provides an easy way to use pandoc attributes:

```
attr = Attributes(['id', ['class1', 'class2'], [['key', 'value']]])

attr.id
>>> 'id'

attr.classes
>>> ['class1', 'class2']

attr['key']
>>> 'value'
```

The original `pandocfilters.attributes` function has the same behaviour
as before:

```
attributes({'id': 'id', 'classes': ['class1', 'class2'], 'key'='value'})
>>> ['id', ['class1', 'class2'], [['key', 'value']]]
```

`Attributes` can read and write attributes in any of these formats:
    - markdown
    - html
    - dictionary
    - pandoc

usage:

```
from pandocfilters import Attributes

attrs = '#id .class1 .class2 key=value'
attributes = Attributes(attrs, format='markdown')

attributes.to_markdown()
>>> '{#id .class1 .class2 key=value}'

attributes.to_dict()
>>> {'id': 'id', 'classes': ['class1', 'class2'], 'key'='value'}

attributes.to_html()
>>> id="id" class="class1 class2" key='value'

attributes.to_pandoc()
>>> ['id', ['class1', 'class2'], [['key', 'value']]]

attributes.id
>>> 'id'

attributes.classes
>>> ['class1', 'class2']

attributes.kvs
>>> OrderedDict([('key', 'value')])

attributes['id']
>>> 'id'

attributes['classes']
>>> ['class1', 'class2']

attributes['key']
>>> 'value'

attributes['new'] = 'another value'
attributes['new']
>>> 'another value'
```
