### PR TITLE
Improve stringfy to handle numbers in YAML header

### DIFF
--- a/pandocfilters.py
+++ b/pandocfilters.py
@@ -71,7 +71,7 @@ def stringify(x):
     result = []
 
     def go(key, val, format, meta):
-        if key == 'Str':
+        if key in ['Str', 'MetaString']:
             result.append(val)
         elif key == 'Code':
             result.append(val[1])


### PR DESCRIPTION
stringfy could handle strings in YAML header

    $ pandoc -t json -f markdown <<EOF
    ---
    str: foo
    ---
    EOF
    [{"unMeta":{"str":{"t":"MetaInlines","c":[{"t":"Str","c":"foo"}]}}},[]]

but could not handle numbers

    $ pandoc -t json -f markdown <<EOF
    ---
    int: 1
    ---
    EOF
    [{"unMeta":{"int":{"t":"MetaString","c":"1"}}},[]]

This small change fix this problem.