### PR TITLE
Change key/value references in metavars

### DIFF
--- a/examples/metavars.md
+++ b/examples/metavars.md
@@ -1,0 +1,5 @@
+﻿---
+author: Caleb Hyde
+---
+
+# %{author}

--- a/examples/metavars.py
+++ b/examples/metavars.py
@@ -18,12 +18,12 @@ def metavars(key, value, format, meta):
         if m:
             field = m.group(1)
             result = meta.get(field, {})
-            if 'MetaInlines' in result:
+            if 'MetaInlines' in result['t']:
                 return Span(attributes({'class': 'interpolated',
                                         'field': field}),
-                            result['MetaInlines'])
-            elif 'MetaString' in result:
-                return Str(result['MetaString'])
+                            result['c'])
+            elif 'MetaString' in result[t]:
+                return Str(result['c'])
 
 if __name__ == "__main__":
     toJSONFilter(metavars)


### PR DESCRIPTION
The `metavars.py` example wasn't working for me. I had to make the attached change to get something like `%{author}` to render the variable. I added a minimal test case, `metavars.md` by way of demonstration:

    $ pandoc --filter examples/metavars.py examples/metavars.md
    <h1 id="author"><span field="author" class="interpolated">Caleb Hyde</span></h1>
    $ pandoc --version
    pandoc 1.13.2.1


