### PR TITLE
Filters for lilypond and gabc

### DIFF
--- a/examples/gabc-sample.md
+++ b/examples/gabc-sample.md
@@ -1,6 +1,7 @@
 ---
 header-includes:
 
+    - \usepackage{libertine}
     - \usepackage[autocompile]{gregoriotex}
 
 ---
@@ -23,9 +24,9 @@ to get
 and this
 
 ~~~~~~
-`gabc-score`{.gabc}
+`gabc-score`{.gabc staffsize=12 annotation=Off. mode=2.}
 ~~~~~~
 
 to get the score in `gabc-score.gabc` :
 
-`gabc-score`{.gabc}
+`gabc-score`{.gabc staffsize=12 annotation=Off. mode=2.}

--- a/examples/gabc-sample.md
+++ b/examples/gabc-sample.md
@@ -1,0 +1,31 @@
+---
+header-includes:
+
+    - \usepackage[autocompile]{gregoriotex}
+
+---
+
+
+Use this
+
+~~~~~~
+```gabc
+(c4) A(f)ve(c) Ma(d)rí(dh'!iv)a.(h.) (::)
+```
+~~~~~~
+
+to get
+
+```gabc
+(c4) A(f)ve(c) Ma(d)rí(dh'!iv)a.(h.) (::)
+```
+
+and this
+
+~~~~~~
+`gabc-score`{.gabc}
+~~~~~~
+
+to get the score in `gabc-score.gabc` :
+
+`gabc-score`{.gabc}

--- a/examples/gabc-score.gabc
+++ b/examples/gabc-score.gabc
@@ -1,0 +1,17 @@
+name:Ave María;
+%%
+(c4) A(fg/hgh fhf/gvFE. d!ef!g'h fhf/gh)ve(g.) *(;)
+Ma(h)rí(jj//jjjvH'GFgh!jvHF'g)a,(g.) (:)
+
+grá(g_d/fv.efd de!f'g)ti(fg)a(g) ple(ghhg)na,(g.) (:)
+
+Dó(jvIHk_j ijh/ig./hi/jg.,jvIHk_j ijh/ig./hi/jg)mi(fg)nus(g.) (,)
+te(ggghvGFg_d//gjhi)cum :(hg..) (:)
+
+be(h)ne(jj)dí(jk/lvlk)cta(jkkj) tu(ji/jkhhg.) (;)
+in(g) mu(gjjvI'H)li(hkj)é(jjvI'H)ri(jvIHij)bus,(i.) (:)
+
+et(g) be(i)ne(jkj)dí(hjgh)ctus(fg!hvhg.) (;)
+fru(g_f/ghffe)ctus(d.) ven(de!f'g/hvF'ED,de!f'g)tris(fhfg) tu(ghhg)i.(g.) (::)
+
+<i>T. P.</i> Al(h!iwji~)le(jkJH'//gi. hjIH'//g!jj/hig___)lú(ghg___)ia.(g.) (::)

--- a/examples/gabc.py
+++ b/examples/gabc.py
@@ -2,6 +2,8 @@
 """
 Pandoc filter to convert code blocks with class "gabc" to LaTeX
 \\gabcsnippet commands in LaTeX output, and to images in HTML output.
+Assumes Ghostscript, LuaLaTeX, [Gregorio](http://gregorio-project.github.io/)
+and a reasonable selection of LaTeX packages are installed.
 """
 
 import os
@@ -89,12 +91,12 @@ def png(contents, outfile, latex_command):
     return src
 
 
-def gabc(key, value, frm, meta):                   # pylint:disable=I0011,W0613
+def gabc(key, value, fmt, meta):                   # pylint:disable=I0011,W0613
     """Handle gabc file inclusion and gabc code block."""
     if key == 'Code':
         [[ident, classes, kvs], contents] = value  # pylint:disable=I0011,W0612
         if "gabc" in classes:
-            if frm == "latex":
+            if fmt == "latex":
                 if ident == "":
                     label = ""
                 else:
@@ -113,7 +115,7 @@ def gabc(key, value, frm, meta):                   # pylint:disable=I0011,W0613
     elif key == 'CodeBlock':
         [[ident, classes, kvs], contents] = value
         if "gabc" in classes:
-            if frm == "latex":
+            if fmt == "latex":
                 if ident == "":
                     label = ""
                 else:

--- a/examples/gabc.py
+++ b/examples/gabc.py
@@ -102,8 +102,9 @@ def latex2png(snippet, outfile):
     )
 
 
-def png(contents, outfile, latex_command):
+def png(contents, latex_command):
     """Creates a png if needed."""
+    outfile = sha(contents + latex_command)
     src = os.path.join(IMAGEDIR, outfile + '.png')
     if not os.path.isfile(src):
         try:
@@ -139,10 +140,9 @@ def gabc(key, value, fmt, meta):                   # pylint:disable=I0011,W0613
                 )
                 with open(infile, 'r') as doc:
                     code = doc.read().split('%%\n')[1]
-                outfile = sha(code)
                 return [Image([], [
                     png(
-                        contents, outfile,
+                        contents,
                         latexsnippet('\\gregorioscore', kvs)
                     ),
                     ""
@@ -163,10 +163,9 @@ def gabc(key, value, fmt, meta):                   # pylint:disable=I0011,W0613
                     label
                     )]
             else:
-                outfile = sha(contents)
                 return Para([Image([], [
                     png(
-                        contents, outfile,
+                        contents,
                         latexsnippet('\\gabcsnippet', kvs)
                     ),
                     ""

--- a/examples/gabc.py
+++ b/examples/gabc.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Pandoc filter to convert code blocks with class "gabc" to LaTeX
+\\gabcsnippet commands in LaTeX output, and to images in HTML output.
+"""
+
+import os
+from sys import getfilesystemencoding, stderr
+from subprocess import Popen, call, PIPE, DEVNULL
+from hashlib import sha1
+from pandocfilters import toJSONFilter, RawBlock, RawInline, Para, Image
+
+
+IMAGEDIR = "tmp_gabc"
+LATEX_DOC = """\\documentclass{article}
+\\usepackage{libertine}
+\\usepackage[autocompile]{gregoriotex}
+\\pagestyle{empty}
+\\begin{document}
+%s
+\\end{document}
+"""
+
+
+def sha(code):
+    """Returns sha1 hash of the code"""
+    return sha1(code.encode(getfilesystemencoding())).hexdigest()
+
+
+def latex(code):
+    """LaTeX inline"""
+    return RawInline('latex', code)
+
+
+def latexblock(code):
+    """LaTeX block"""
+    return RawBlock('latex', code)
+
+
+def htmlblock(code):
+    """Html block"""
+    return RawBlock('html', code)
+
+
+def latex2png(snippet, outfile):
+    """Compiles a LaTeX snippet to png"""
+    pngimage = os.path.join(IMAGEDIR, outfile + '.png')
+    environment = os.environ
+    environment['openout_any'] = 'a'
+    environment['shell_escape_commands'] = \
+        "bibtex,bibtex8,kpsewhich,makeindex,mpost,repstopdf,gregorio"
+    proc = Popen(
+        ["lualatex", '-output-directory=' + IMAGEDIR],
+        stdin=PIPE,
+        stdout=DEVNULL,
+        env=environment
+    )
+    proc.stdin.write(
+        (
+            LATEX_DOC % (snippet)
+        ).encode("utf-8")
+    )
+    proc.communicate()
+    proc.stdin.close()
+    call(["pdfcrop", os.path.join(IMAGEDIR, "texput.pdf")], stdout=DEVNULL)
+    call(
+        [
+            "gs",
+            "-sDEVICE=pngalpha",
+            "-r144",
+            "-sOutputFile=" + pngimage,
+            os.path.join(IMAGEDIR, "texput-crop.pdf"),
+        ],
+        stdout=DEVNULL,
+    )
+
+
+def png(contents, outfile, latex_command):
+    """Creates a png if needed."""
+    src = os.path.join(IMAGEDIR, outfile + '.png')
+    if not os.path.isfile(src):
+        try:
+            os.mkdir(IMAGEDIR)
+            stderr.write('Created directory ' + IMAGEDIR + '\n')
+        except OSError:
+            pass
+        latex2png(latex_command + "{" + contents + "}", outfile)
+        stderr.write('Created image ' + src + '\n')
+    return src
+
+
+def gabc(key, value, frm, meta):                   # pylint:disable=I0011,W0613
+    """Handle gabc file inclusion and gabc code block."""
+    if key == 'Code':
+        [[ident, classes, kvs], contents] = value  # pylint:disable=I0011,W0612
+        if "gabc" in classes:
+            if frm == "latex":
+                if ident == "":
+                    label = ""
+                else:
+                    label = '\\label{' + ident + '}'
+                return latex('\\includescore{' + contents + '}' + label)
+            else:
+                infile = contents + (
+                    '.gabc' if '.gabc' not in contents else ''
+                )
+                with open(infile, 'r') as doc:
+                    code = doc.read().split('%%\n')[1]
+                outfile = sha(code)
+                return [
+                    Image([], [png(contents, outfile, '\\includescore'), ""])
+                ]
+    elif key == 'CodeBlock':
+        [[ident, classes, kvs], contents] = value
+        if "gabc" in classes:
+            if frm == "latex":
+                if ident == "":
+                    label = ""
+                else:
+                    label = '\\label{' + ident + '}'
+                return [latexblock('\\gabcsnippet{' + contents + '}' + label)]
+            else:
+                outfile = sha(contents)
+                return Para(
+                    [Image([], [png(contents, outfile, '\\gabcsnippet'), ""])]
+                )
+
+
+if __name__ == "__main__":
+    toJSONFilter(gabc)

--- a/examples/lilypond-sample.md
+++ b/examples/lilypond-sample.md
@@ -1,0 +1,31 @@
+---
+header-includes:
+
+    - \usepackage{lyluatex}
+
+---
+
+
+Use this
+
+~~~~~~
+```ly
+\relative c' { c4 d e f g a b c }
+```
+~~~~~~
+
+to get
+
+```ly
+\relative c' { c4 d e f g a b c }
+```
+
+and this
+
+~~~~~~
+`lilypond-score`{.ly}
+~~~~~~
+
+to get the score in `ly-score.ly` :
+
+`lilypond-score`{.ly}

--- a/examples/lilypond-sample.md
+++ b/examples/lilypond-sample.md
@@ -23,9 +23,9 @@ to get
 and this
 
 ~~~~~~
-`lilypond-score`{.ly}
+`lilypond-score`{.ly staffsize=12}
 ~~~~~~
 
 to get the score in `ly-score.ly` :
 
-`lilypond-score`{.ly}
+`lilypond-score`{.ly staffsize=12}

--- a/examples/lilypond-score.ly
+++ b/examples/lilypond-score.ly
@@ -1,0 +1,98 @@
+\version "2.18"
+\language "français"
+
+\header {
+  tagline = ""
+  composer = ""
+}
+
+MetriqueArmure = {
+  \tempo 2.=50
+  \time 6/4
+  \key sib \major
+}
+
+italique = { \override Score . LyricText #'font-shape = #'italic }
+
+roman = { \override Score . LyricText #'font-shape = #'roman }
+
+MusiqueCouplet = \relative do' {
+  \partial 2. re4\p re^"Solo" re
+  sol2. la2 la4
+  sib2 sib4 \breathe
+  la4 sib la
+  sol2. \acciaccatura {la16[ sol]} fad2 sol4
+  la2 r4 re,2 re4
+  sol2 sol4 la\< sol la
+  sib2\! \acciaccatura {la16[ sol]} fa4 \breathe sib2 do4
+  re2 do4 sol2 la4
+  sib2. ~ sib2 \bar "||"
+}
+
+MusiqueRefrainI = \relative do'' {
+  re4\f^"Chœur"
+  re2 do4 sib2 la4
+  sol2. fad2 \breathe re4
+  sol2 la4 sib2 do4
+  re2.~ re4 \oneVoice r \voiceOne re\f
+  re2 do4 sib2 la4
+  sol2. fad2 \oneVoice r4 \voiceOne
+  sol2 la4\< sib la sol\!
+  la2. sib2( la4)
+  sol2.\fermata \bar "|."
+}
+
+MusiqueRefrainII = \relative do'' {
+  sib4
+  sib2 la4 sol2 re4
+  mib4 re dod re2 do4
+  sib2 re4 sol2 sol4
+  fad2.~ fad4 s sib4
+  sib2 la4 sol2 re4
+  mib4 re dod re2 s4
+  sib2 do4 re do sib
+  do2. re2( do4)
+  sib2.
+}
+
+ParolesCouplet = \lyricmode {
+  Le soir é -- tend sur la Ter -- re
+  Son grand man -- teau de ve -- lours,
+  Et le camp, calme et so -- li -- tai -- re,
+  Se re -- cueille en ton a -- mour.
+}
+
+ParolesRefrain = \lyricmode {
+  \italique
+  Ô Vier -- ge de lu -- miè -- re,
+  É -- toi -- le de nos cœurs,
+  En -- tends no -- tre pri -- è -- re,
+  No -- tre_- Da -- me des É -- clai -- reurs_!
+}
+
+\score{
+  <<
+    \new Staff <<
+      \set Staff.midiInstrument = "flute"
+      \set Staff.autoBeaming = ##f
+      \new Voice = "couplet" {
+        \override Score.PaperColumn #'keep-inside-line = ##t
+        \MetriqueArmure
+        \MusiqueCouplet
+        \voiceOne
+        \MusiqueRefrainI
+      }
+        \new Voice = "refrainII" {
+          s4*50
+          \voiceTwo
+          \MusiqueRefrainII
+        }
+    >>
+    \new Lyrics \lyricsto couplet {
+      \ParolesCouplet
+      \ParolesRefrain
+    }
+  >>
+  \layout{}
+  \midi{}
+}

--- a/examples/lilypond.py
+++ b/examples/lilypond.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+"""
+Pandoc filter to process code blocks with class "ly" containing
+Lilypond notation.  Assumes that Lilypond and Ghostscript are
+installed, plus [lyluatex](https://github.com/jperon/lyluatex) package for
+LaTeX, with LuaLaTeX.
+"""
+
+import os
+from sys import getfilesystemencoding, stderr
+from subprocess import Popen, call, PIPE
+from hashlib import sha1
+from pandocfilters import toJSONFilter, Para, Image, RawInline, RawBlock
+
+IMAGEDIR = "tmp_ly"
+LATEX_DOC = """\\documentclass{article}
+\\usepackage{libertine}
+\\usepackage{lyluatex}
+\\pagestyle{empty}
+\\begin{document}
+%s
+\\end{document}
+"""
+
+
+def sha(x):
+    return sha1(x.encode(getfilesystemencoding())).hexdigest()
+
+
+def latex(code):
+    """LaTeX inline"""
+    return RawInline('latex', code)
+
+
+def latexblock(code):
+    """LaTeX block"""
+    return RawBlock('latex', code)
+
+
+def ly2png(lily, outfile):
+    p = Popen([
+        "lilypond",
+        "-dno-point-and-click",
+        "-dbackend=eps",
+        "-djob-count=2",
+        "-ddelete-intermediate-files",
+        "-o", outfile,
+        "-"
+    ], stdin=PIPE, stdout=-3)
+    p.stdin.write(("\\paper{\n"
+        "indent=0\\mm\n"
+        "oddFooterMarkup=##f\n"
+        "oddHeaderMarkup=##f\n"
+        "bookTitleMarkup = ##f\n"
+        "scoreTitleMarkup = ##f\n"
+        "}\n" +
+        lily).encode("utf-8"))
+    p.communicate()
+    p.stdin.close()
+    call([
+        "gs",
+        "-sDEVICE=pngalpha",
+        "-r144",
+        "-sOutputFile=" + outfile + '.png',
+        outfile + '.pdf',
+    ], stdout=-3)
+
+
+def png(contents):
+    """Creates a png if needed."""
+    outfile = os.path.join(IMAGEDIR, sha(contents))
+    src = outfile + '.png'
+    if not os.path.isfile(src):
+        try:
+            os.mkdir(IMAGEDIR)
+            stderr.write('Created directory ' + IMAGEDIR + '\n')
+        except OSError:
+            pass
+        ly2png(contents, outfile)
+        stderr.write('Created image ' + src + '\n')
+    return src
+
+
+def lily(key, value, fmt, meta):
+    if key == 'Code':
+        [[ident, classes, kvs], contents] = value  # pylint:disable=I0011,W0612
+        if "ly" in classes:
+            if fmt == "latex":
+                if ident == "":
+                    label = ""
+                else:
+                    label = '\\label{' + ident + '}'
+                return latex('\\includely{' + contents + '}' + label)
+            else:
+                infile = contents + (
+                    '.ly' if '.ly' not in contents else ''
+                )
+                stderr.write(infile + '\n')
+                with open(infile, 'r') as doc:
+                    code = doc.read()
+                return [
+                    Image([], [png(code), ""])
+                ]
+    if key == 'CodeBlock':
+        [[ident, classes, keyvals], code] = value
+        if "ly" in classes:
+            if fmt == "latex":
+                if ident == "":
+                    label = ""
+                else:
+                    label = '\\label{' + ident + '}'
+                return latexblock('\\lily{' + code + '}' + label)
+            else:
+                return Para([Image([], [png(code), ""])])
+
+if __name__ == "__main__":
+    toJSONFilter(lily)


### PR DESCRIPTION
Those filters allow integrating : 

- classical partitions, thanks to [lilypond](http://www.lilypond.org) and [lyluatex](https://github.com/jperon/lyluatex) (for the latex part) ; 
- gregorian partitions, thanks to [gregorio](https://github.com/gregorio-project/gregorio).

Both need ghostscript for conversion from pdf to png when generating non-latex documents.