### PR TITLE
Fixes jgm/pandocfilters#21 (incorrect stdin decoding)

### DIFF
--- a/pandocfilters.py
+++ b/pandocfilters.py
@@ -9,6 +9,7 @@ AST serialized as JSON.
 
 import sys
 import json
+import io
 
 
 def walk(x, action, format, meta):
@@ -55,7 +56,8 @@ def toJSONFilter(action):
     the list to which the target object belongs.    (So, returning an
     empty list deletes the object.)
     """
-    doc = json.loads(sys.stdin.read())
+    input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
+    doc = json.loads(input_stream.read())
     if len(sys.argv) > 1:
         format = sys.argv[1]
     else:


### PR DESCRIPTION
On Windows 7 (and with Python 3), stdin may use the wrong codec which
conflicts with Pandoc producing utf-8 JSON.

This patch explicly sets the encoding to utf-8

Note that io was introduced on Python 2.6 (
https://docs.python.org/2/library/io.html ) so extremely old Python
distributions will break with this change.