### PR TITLE
Allow pandocfilters to modify metadata block

### DIFF
--- a/pandocfilters.py
+++ b/pandocfilters.py
@@ -73,8 +73,8 @@ def toJSONFilters(actions):
         format = sys.argv[1]
     else:
         format = ""
-    altered = reduce(lambda x, action: walk(x, action, format, doc[0]['unMeta']), actions, doc)
-    json.dump(altered, sys.stdout)
+    doc[1] = reduce(lambda x, action: walk(x, action, format, doc[0]['unMeta']), actions, doc[1])
+    json.dump(doc, sys.stdout)
 
 
 def stringify(x):


### PR DESCRIPTION
It is not currently possible to modify metadata block while walking the tree. This pull request allows that feature.

Fixes #23