### PR TITLE
new plugin: plantuml

### DIFF
--- a/README
+++ b/README
@@ -146,6 +146,10 @@ for developing your own pandocfilters.
     macro ``\myemph{...}`` rather than ``\emph{...}`` in latex. Other output
     formats are unaffected.
 
+``plantuml.py``
+    Pandoc filter to process code blocks with class ``plantuml`` to images.
+    Needs `plantuml.jar` from http://plantuml.com/.
+
 ``theorem.py``
     Pandoc filter to convert divs with ``class="theorem"`` to LaTeX theorem
     environments in LaTeX output, and to numbered theorems in HTML

--- a/examples/plantuml-sample.md
+++ b/examples/plantuml-sample.md
@@ -1,0 +1,37 @@
+Use this
+
+
+```
+Alice -> Bob: Authentication Request
+Bob --> Alice: Authentication Response
+
+Alice -> Bob: Another authentication Request
+Alice <-- Bob: another authentication Response
+```
+
+to get 
+
+```plantuml
+Alice -> Bob: Authentication Request
+Bob --> Alice: Authentication Response
+
+Alice -> Bob: Another authentication Request
+Alice <-- Bob: another authentication Response
+```
+
+with Äüö
+
+```plantuml
+Älöc -> Bob: Authentication Request
+Bob --> Älöc: Authentication Response
+
+Älöc -> Bob: Another authentication Request
+Älöc <-- Bob: another authentication Response
+```
+
+See [whatever](#whatever) for an example with options `{.plantuml #whatever caption="this is the caption" width=65%}`
+
+```{.plantuml #whatever caption="this is the caption" width=65%}
+Alice -> Bob: Authentication Request
+Bob --> Alice: Authentication Response
+```

--- a/examples/plantuml.py
+++ b/examples/plantuml.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+
+"""
+Pandoc filter to process code blocks with class "plantuml" into
+plant-generated images.
+"""
+
+import hashlib
+import os
+import sys
+from pandocfilters import toJSONFilter, Str, Para, Image
+from subprocess import call
+
+
+imagedir = "plantuml-images"
+
+def sha1(x):
+    return hashlib.sha1(x.encode(sys.getfilesystemencoding())).hexdigest()
+
+
+def filter_keyvalues(kv):
+  res = []
+  caption = []
+  for k,v in kv:
+    if k == u"caption":
+      caption = [ Str(v) ]
+    else:
+      res.append( [k,v] )
+
+  return caption, "fig:" if caption else "", res
+
+
+def plantuml(key, value, format, meta):
+    if key == 'CodeBlock':
+        [[ident, classes, keyvals], code] = value
+
+        if "plantuml" in classes:
+            caption, typef, keyvals = filter_keyvalues(keyvals)
+
+            filename = sha1(code)
+            if format == "html":
+                filetype = "svg"
+            elif format == "latex":
+                filetype = "eps"
+            else:
+                filetype = "png"
+            src = os.path.join(imagedir, filename + '.uml')
+            dest = os.path.join(imagedir, filename + '.' + filetype)
+
+            if not os.path.isfile(dest):
+                try:
+                    os.mkdir(imagedir)
+                    sys.stderr.write('Created directory ' + imagedir + '\n')
+                except OSError:
+                    pass
+
+                txt =  code.encode("utf-8")
+                if not txt.startswith("@start"):
+                    txt = "@startuml\n" + txt + "\n@enduml\n"
+                with open(src, "w") as f:
+                    f.write(txt)
+
+                call(["java", "-jar", "plantuml.jar", "-t"+filetype, src])
+
+                sys.stderr.write('Created image ' + dest + '\n')
+
+            return Para([Image([ident, [], keyvals], caption, [dest, typef])])
+
+if __name__ == "__main__":
+    toJSONFilter(plantuml)


### PR DESCRIPTION
Dear John,

this pull-request includes a new filter to create uml diagrams with the help of  plantuml from http://plantuml.com/.

Additional question: I have managed to allow options like width, an id and a caption for the generated image. Would you merge a patch which moves this to either a generic "util.py" or even to "pandocfilters.py"? I would also replace the repeated code from the other filters.

The steps to create a directory for the results (images) is also repeated in many filter and could be "unified" in a similar way.

Regards
August

