### PR TITLE
Separate writing from filter application in toJSONFilters

### DIFF
--- a/pandocfilters.py
+++ b/pandocfilters.py
@@ -149,12 +149,18 @@ def toJSONFilters(actions):
         # REF: https://stackoverflow.com/questions/2467928/python-unicodeencode
         input_stream = codecs.getreader("utf-8")(sys.stdin)
 
-    doc = json.loads(input_stream.read())
+    source = input_stream.read()
     if len(sys.argv) > 1:
         format = sys.argv[1]
     else:
         format = ""
 
+    sys.stdout.write(applyJSONFilters(actions, source, format))
+
+def applyJSONFilters(actions, source, format=""):
+    
+    doc = json.loads(source)
+    
     if 'meta' in doc:
         meta = doc['meta']
     elif doc[0]:  # old API
@@ -165,8 +171,8 @@ def toJSONFilters(actions):
     for action in actions:
         altered = walk(altered, action, format, meta)
 
-    json.dump(altered, sys.stdout)
-
+    return json.dumps(altered)
+    
 
 def stringify(x):
     """Walks the tree x and returns concatenated string content,

--- a/pandocfilters.py
+++ b/pandocfilters.py
@@ -115,7 +115,7 @@ def toJSONFilter(action):
 
 
 def toJSONFilters(actions):
-    """Generate a JSON-to-JSON filter
+    """Generate a JSON-to-JSON filter from stdin to stdout
 
     The filter:
 
@@ -158,7 +158,40 @@ def toJSONFilters(actions):
     sys.stdout.write(applyJSONFilters(actions, source, format))
 
 def applyJSONFilters(actions, source, format=""):
+    """Walk through JSON structure and apply filters
     
+    This:
+
+    * reads a JSON-formatted pandoc document from a source string
+    * transforms it by walking the tree and performing the actions
+    * returns a new JSON-formatted pandoc document as a string 
+    
+    The argument `actions` is a list of functions of the form
+    `action(key, value, format, meta)`, where:
+
+    * `key` is the type of the pandoc object (e.g. 'Str', 'Para') `value` is
+    * the contents of the object (e.g. a string for 'Str', a list of
+      inline elements for 'Para')
+    * `format` is the target output format (which will be taken for the first
+      command line argument if present)
+    * `meta` is the document's metadata
+
+    The return of an action is either:
+
+    * `None`: this means that the object should remain unchanged
+    * a pandoc object: this will replace the original object
+    * a list of pandoc objects: these will replace the original object; the
+      list is merged with the neighbors of the orignal objects (spliced into
+      the list the original object belongs to); returning an empty list deletes
+      the object
+    
+    The argument `source` is a string encoded JSON object
+    
+    The argument `format` is a string describing the output format
+    
+    Returns a the new JSON-formatted pandoc document
+    """
+
     doc = json.loads(source)
     
     if 'meta' in doc:


### PR DESCRIPTION
This separates the current `toJSONFilters` functionality into two parts: 
  * `toJSONFilters` (which maintains the previous API, writes to stdout, reads from stdin, and extracts command line arguments)
  * `applyJSONFilters` (which works on JSON strings, iterating through and applying the filters).

This is needed to be able to use JSONfilters written for pandoc within an already existing python process (related to finding a solution to https://github.com/jupyter/nbconvert/issues/11 with a particular application to be found at https://github.com/jupyter/nbconvert/pull/458). 

With help from @takluyver & inspiration from https://github.com/takluyver/bookbook.