### PR TITLE
Change elt() to return a list instead of tuple when numargs > 1

### DIFF
--- a/pandocfilters.py
+++ b/pandocfilters.py
@@ -245,7 +245,7 @@ def elt(eltType, numargs):
         elif len(args) == 1:
             xs = args[0]
         else:
-            xs = args
+            xs = list(args)
         return {'t': eltType, 'c': xs}
     return fun
 


### PR DESCRIPTION
Multi-argument elements created by the element constructors (Header(), Link(), etc.) return tuples. The walk() function only traverses lists and not tuples, so will process elements passed from Pandoc, but not elements created internally by constructors. Presuming this is a bug, a fix could change walk() to accept tuples, or change elt() to return lists. Here is a patch for the latter.