### PR TITLE
Update for new leaf node format introduced in Pandoc 1.18

### DIFF
--- a/pandocfilters.py
+++ b/pandocfilters.py
@@ -241,7 +241,7 @@ def elt(eltType, numargs):
             raise ValueError(eltType + ' expects ' + str(numargs) +
                              ' arguments, but given ' + str(lenargs))
         if numargs == 0:
-            xs = []
+            return {'t': eltType}
         elif len(args) == 1:
             xs = args[0]
         else:


### PR DESCRIPTION
From the Pandoc changelog:
"Leaf nodes no longer have an empty array for their “c” value. Thus, for example, a Space is encoded as {"t":"Space"} rather than {"t":"Space","c":[]} as before."