### PR TITLE
added gitlab_markdown_math convert filter

### DIFF
--- a/examples/gitlab_markdown-sample.md
+++ b/examples/gitlab_markdown-sample.md
@@ -1,0 +1,13 @@
+Use this
+
+```math
+a^2 + b^2 = c^2
+```
+
+to get 
+
+$$
+a^2 + b^2 = c^2
+$$
+
+also you go from $`a^2 + b^2 = c^2`$ to $a^2 + b^2 = c^2$

--- a/examples/gitlab_markdown.py
+++ b/examples/gitlab_markdown.py
@@ -1,0 +1,23 @@
+from pandocfilters import toJSONFilter, Math, Para
+"""
+Pandoc filter to convert gitlab flavored markdown to pandoc flavored markdown
+"""
+
+
+def gitlab_markdown(key, value, format, meta):
+    if key == "CodeBlock":
+        [[identification, classes, keyvals], code] = value
+        if classes[0] == "math":
+            fmt = {'t': 'DisplayMath',
+                   'c': []}
+            return Para([Math(fmt, code)])
+
+    elif key == "Math":
+        [fmt, code] = value
+        if isinstance(fmt, dict) and fmt['t'] == "InlineMath":
+            # if fmt['t'] == "InlineMath":
+            return Math(fmt, code.strip('`'))
+
+
+if __name__ == "__main__":
+    toJSONFilter(gitlab_markdown)


### PR DESCRIPTION
this pandoc filter converts the math in gitlab flavored markdown files to pandoc markdown compatible format