### PR TITLE
Allow specifying filename for graphviz filter

### DIFF
--- a/examples/graphviz.py
+++ b/examples/graphviz.py
@@ -23,7 +23,12 @@ def graphviz(key, value, format, _):
             filetype = get_extension(format, "png", html="png", latex="pdf")
             dest = get_filename4code("graphviz", code, filetype)
 
-            if not os.path.isfile(dest):
+            filename = ""
+            for a,b in keyvals:
+                if(a == "filename"):
+                    filename = "graphviz-images/"+b+"."+filetype
+                    dest = filename
+            if (filename != "") or (not os.path.isfile(dest)):
                 g = pygraphviz.AGraph(string=code)
                 g.layout()
                 g.draw(dest, prog=prog)

--- a/examples/graphviz.py
+++ b/examples/graphviz.py
@@ -9,6 +9,7 @@ Needs pygraphviz
 
 import os
 import sys
+import string
 
 import pygraphviz
 
@@ -22,12 +23,14 @@ def graphviz(key, value, format, _):
             prog, keyvals = get_value(keyvals, u"prog", u"dot")
             filetype = get_extension(format, "png", html="png", latex="pdf")
             dest = get_filename4code("graphviz", code, filetype)
-
             filename = ""
-            for a,b in keyvals:
+            for a,fname in keyvals:
                 if(a == "filename"):
-                    filename = "graphviz-images/"+b+"."+filetype
-                    dest = filename
+                    valid_chars = "-_ %s%s" % (string.ascii_letters, string.digits)
+                    fname = ''.join(x for x in fname if x in valid_chars)
+                    if fname != "":
+                        filename = "graphviz-images/"+fname+"."+filetype
+                        dest = filename
             if (filename != "") or (not os.path.isfile(dest)):
                 g = pygraphviz.AGraph(string=code)
                 g.layout()


### PR DESCRIPTION
My document gets confusing as I add more graphviz images, and I have to manually cache them for other visualizations.

Use case: I write latex and get pdf images, but also convert them to jpg and add them in a commented section of my markdown, for easy visualization of other users.

Example for notation (just added a `filename` option):

```
~~~~ {.graphviz #fig:test caption="test figure" width=90% filename="test"}
```
would generate test.pdf (for LaTeX) under graphviz-images/ folder

if 'filename' not specified, a hashed name would be generated, as usual.

Drawbacks: file is re-generated every time I'm using filename. Perhaps it's also useful as a prefix for the hashed name, that would allow not re-renerating, and also facilitate finding the exact image on graphviz-images folder.
Another possible problem: name needs to be sanitized, otherwise can overwrite files on other folders...