### PR TITLE
Fix two bugs in gitlab_markdown.py

### DIFF
--- a/examples/gitlab_markdown-sample.md
+++ b/examples/gitlab_markdown-sample.md
@@ -4,10 +4,20 @@ Use this
 a^2 + b^2 = c^2
 ```
 
-to get 
+to get
 
 $$
 a^2 + b^2 = c^2
 $$
 
 also you go from $`a^2 + b^2 = c^2`$ to $a^2 + b^2 = c^2$
+
+`inline code`
+
+```
+fenced non-math code
+    block
+```
+
+    non-math code block
+    by indentation

--- a/examples/gitlab_markdown.py
+++ b/examples/gitlab_markdown.py
@@ -9,7 +9,7 @@ Pandoc filter to convert gitlab flavored markdown to pandoc flavored markdown
 def gitlab_markdown(key, value, format, meta):
     if key == "CodeBlock":
         [[identification, classes, keyvals], code] = value
-        if classes[0] == "math":
+        if len(classes) > 0 and classes[0] == "math":
             fmt = {'t': 'DisplayMath',
                    'c': []}
             return Para([Math(fmt, code)])

--- a/examples/gitlab_markdown.py
+++ b/examples/gitlab_markdown.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from pandocfilters import toJSONFilter, Math, Para
 """
 Pandoc filter to convert gitlab flavored markdown to pandoc flavored markdown


### PR DESCRIPTION
These two fixes make the filter usable as in `pandoc -F /path/to/gitlab_markdown.py`.