### PR TITLE
gitignore: add *.egg-info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 tmp_ly/
 *-sample.pdf
 .idea/
+*.egg-info/
 examples/lyluatex.lua
 examples/lyluatex.sty
 examples/plantuml.jar


### PR DESCRIPTION
Ignore metadata generated during install, for instance `pip install .`