### PR TITLE
Also return modified metadata with JSON output

### DIFF
--- a/pandocfilters.py
+++ b/pandocfilters.py
@@ -211,7 +211,7 @@ def applyJSONFilters(actions, source, format=""):
     altered = doc
     for action in actions:
         altered = walk(altered, action, format, meta)
-
+    altered['meta'] = meta
     return json.dumps(altered)
 
 


### PR DESCRIPTION
Sometimes, a filter should extract information from the document and set metadata variables accordingly - e.g., for use in templates.
In my use case, I want to extract data from an *Abstract* section and add it to the metadata dictionary so that it can be used in the LaTeX template outside the document body.
While all filters get a reference to the `meta` dictionary that was extracted from the source JSON file, the the (possibly modified) `meta` dictionary is not added to the JSON *output*. 
With this patch, `applyJSONFilters()` filter also outputs the metadata dictionary which all filters in the Python script can modify.