### PR TITLE
Do not spam `Created directory` to stderr on each get_filename4code

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -44,10 +44,13 @@ jobs:
           # - 2.11.4
           # - 2.12
           - latest
+        # The empty env for all python but 3.5
+        pip-trusted-host: [""]
         include:
           - os: ubuntu-20.04
             python-version: 3.5
             pandoc-version: latest
+            pip-trusted-host: "pypi.python.org pypi.org files.pythonhosted.org"
           - os: ubuntu-20.04
             python-version: 3.6
             pandoc-version: latest
@@ -59,6 +62,8 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+      env:
+        PIP_TRUSTED_HOST: ${{ matrix.pip-trusted-host }}
     - name: Install examples' dependencies
       run: sudo apt update && sudo apt install abcm2ps graphviz graphviz-dev texlive-full
     - name: Install dependencies—pip

--- a/pandocfilters.py
+++ b/pandocfilters.py
@@ -47,11 +47,12 @@ def get_filename4code(module, content, ext=None):
     else:
         imagedir = module + "-images"
     fn = hashlib.sha1(content.encode(sys.getfilesystemencoding())).hexdigest()
-    try:
-        os.makedirs(imagedir, exist_ok=True)
-        sys.stderr.write('Created directory ' + imagedir + '\n')
-    except OSError:
-        sys.stderr.write('Could not create directory "' + imagedir + '"\n')
+    if not os.path.isdir(imagedir):
+        try:
+            os.makedirs(imagedir)
+            sys.stderr.write('Created directory ' + imagedir + '\n')
+        except OSError:
+            sys.stderr.write('Could not create directory "' + imagedir + '"\n')
     if ext:
         fn += "." + ext
     return os.path.join(imagedir, fn)


### PR DESCRIPTION
Hi. Each time the `get_filename4code` is called, it prints `Created directory name`, see https://github.com/timofurrer/pandoc-plantuml-filter/issues/29 and https://github.com/timofurrer/pandoc-plantuml-filter/issues/25

It will work as well, when the imagedir is symlink

```
In [3]: os.path.isdir('test-symlink')
Out[3]: True

In [6]: ls -l test-symlink
lrwxrwxrwx 1 felixoid felixoid 8 Jun 23 16:49 test-symlink -> examples/
```